### PR TITLE
Correct silverstripe-intercom dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "silverstripe/framework": "^3.2",
         "unclecheese/display-logic": "1.3.*",
         "silverstripe/userforms": "^3.0",
-        "sminnee/silverstripe-intercom": "dev-master"
+        "sminnee/silverstripe-intercom": "^1"
     },
     "license": "BSD-3-Clause",
     "authors": [


### PR DESCRIPTION
dev-master is wrong at all times, but especially now that this refers to the 4.x-compatible version of this library ;-)